### PR TITLE
Add --password option if PGPASSWORD is set

### DIFF
--- a/postgres-s3-backup/backup.sh
+++ b/postgres-s3-backup/backup.sh
@@ -13,6 +13,8 @@ export PGPORT=${PGPORT:-$POSTGRES_PORT_5432_TCP_PORT}
 
 # Use pg_dump if database name is specified
 [ -z "$PGDATABASE" ] && CMD=pg_dumpall || CMD=pg_dump
+# Use password authentication if a password is set
+[ ! -z "$PGPASSWORD" ] && CMD="${CMD} --password"
 # Add database name as suffix to name
 [ ! -z "$PGDATABASE" ] && NAME_PREFIX="${NAME_PREFIX}_${PGDATABASE}"
 


### PR DESCRIPTION
Otherwise, "pg_dump will waste a connection attempt finding out that the server wants a password" (from [documentation](https://www.postgresql.org/docs/9.5/static/app-pgdump.html))
